### PR TITLE
Increase timeout to three minutes from three seconds

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -4,7 +4,7 @@ Description: Custom Resource to sets tags on a S3 bucket
 
 Globals:
   Function:
-    Timeout: 3
+    Timeout: 180
 
 Resources:
   SetBucketTagsFunction:


### PR DESCRIPTION
The bucket tagger is timing out, so increase the timeout.